### PR TITLE
The provided tensorflow version is depricated

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-tensorflow==2.1.2
+tensorflow
 numpy==1.18.2
 opencv-python==4.2.0.34
 PyYAML==5.3.1


### PR DESCRIPTION
The provided tensorflow version is depricated
![Screenshot from 2020-10-05 21-58-54](https://user-images.githubusercontent.com/47980147/95106542-4750ed80-0756-11eb-9020-cc75cbd5a971.png)

By just making it tensorflow in the requirements.txt the following error is fixed